### PR TITLE
Redis v6 (current stable) is not compatible with CentOS 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,14 @@ RUN yum -y install wget
 
 RUN yum -y groupinstall "Development Tools"
 
-RUN wget http://download.redis.io/redis-stable.tar.gz \
-    && tar xvzf redis-stable.tar.gz \
-    && pushd redis-stable \
+RUN wget https://github.com/antirez/redis/archive/5.0.9.tar.gz \
+    && tar xvzf 5.0.9.tar.gz \
+    && pushd redis-5.0.9 \
     && make \
     && cp src/redis-cli /usr/local/bin/ \
     && chmod 755 /usr/local/bin/redis-cli \
     && popd \
-    && rm -rf ./redis-stable*
+    && rm -rf ./redis-5.0.9*
 
 # Upgrade python pip
 RUN pip install --upgrade pip


### PR DESCRIPTION
Problem: row 29 fails building redis-cli (stable version)

Cause: row 13 in CentOS 7 installs gcc v4.8.5 but [gcc >= 4.9 is required to build redis v6](https://stackoverflow.com/a/61648254) (current stable version)

Solution: stick to redis v5.0.9 (last version of v5 branch)